### PR TITLE
[DGODP-229] Allow oneOf() to be used exclusively or in addition to existing rules

### DIFF
--- a/fixtures/test_one_of_default.json
+++ b/fixtures/test_one_of_default.json
@@ -1,6 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/TestUserOneOf",
+  "oneOf": [
+    {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/Tester"
+    },
+    {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/Developer"
+    }
+  ],
   "definitions": {
     "Developer": {
       "required": [
@@ -9,65 +17,30 @@
       ],
       "properties": {
         "experience": {
-          "$ref": "#/definitions/StringOrNull",
-          "minLength": 1
+          "minLength": 1,
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "language": {
-          "$ref": "#/definitions/StringOrNull",
-          "pattern": "\\S+"
+          "pattern": "\\S+",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "type": "object"
-    },
-    "StringOrNull": {
-      "required": [
-        "String",
-        "IsNull"
-      ],
-      "properties": {
-        "IsNull": {
-          "type": "boolean"
-        },
-        "String": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "TestUserOneOf": {
-      "required": [
-        "tester",
-        "developer"
-      ],
-      "properties": {
-        "developer": {
-          "$ref": "#/definitions/Developer"
-        },
-        "tester": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/Tester"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Tester"
-        },
-        {
-          "$ref": "#/definitions/Developer"
-        }
-      ]
     },
     "Tester": {
       "required": [
@@ -75,8 +48,14 @@
       ],
       "properties": {
         "experience": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/StringOrNull"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,

--- a/fixtures/test_one_of_default.json
+++ b/fixtures/test_one_of_default.json
@@ -13,7 +13,8 @@
     "Developer": {
       "required": [
         "experience",
-        "language"
+        "language",
+        "hardware"
       ],
       "properties": {
         "experience": {
@@ -27,6 +28,10 @@
             }
           ]
         },
+        "hardware": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/Hardware"
+        },
         "language": {
           "pattern": "\\S+",
           "oneOf": [
@@ -37,6 +42,44 @@
               "type": "null"
             }
           ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Hardware": {
+      "required": [
+        "memory"
+      ],
+      "properties": {
+        "memory": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "oneOf": [
+        {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/Laptop"
+        },
+        {
+          "$ref": "#/definitions/Hardware"
+        }
+      ]
+    },
+    "Laptop": {
+      "required": [
+        "brand",
+        "need_touchscreen"
+      ],
+      "properties": {
+        "brand": {
+          "pattern": "^(apple|lenovo|dell)$",
+          "type": "string"
+        },
+        "need_touchscreen": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/reflect.go
+++ b/reflect.go
@@ -157,12 +157,7 @@ type oneOf interface {
 	OneOf() []reflect.StructField
 }
 
-type optionalString interface {
-	OptionalString() []reflect.StructField
-}
-
 var protoEnumType = reflect.TypeOf((*protoEnum)(nil)).Elem()
-var optionalStringType = reflect.TypeOf((*optionalString)(nil)).Elem()
 var oneOfType = reflect.TypeOf((*oneOf)(nil)).Elem()
 
 func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
@@ -177,14 +172,6 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		return &Type{OneOf: []*Type{
 			{Type: "string"},
 			{Type: "integer"},
-		}}
-	}
-
-	// return oneOf realization for structures.
-	if t.Implements(optionalStringType) {
-		return &Type{OneOf: []*Type{
-			{Type: "string"},
-			{Type: "null"},
 		}}
 	}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -133,6 +133,7 @@ type Tester struct {
 type Developer struct {
 	Experience StringOrNull `json:"experience" jsonschema:"minLength=1"`
 	Language   StringOrNull `json:"language" jsonschema:"required,pattern=\\S+"`
+	HardwareChoice Hardware  `json:"hardware"`
 }
 
 type StringOrNull struct {
@@ -140,11 +141,32 @@ type StringOrNull struct {
 	IsNull bool
 }
 
+type Hardware struct {
+	Memory int `json:"memory" jsonschema:"required"`
+}
+
+type Laptop struct {
+	Brand string `json:"brand" jsonschema:"pattern=^(apple|lenovo|dell)$"`
+	NeedTouchScreen bool `json:"need_touchscreen"`
+}
+
+type Desktop struct {
+	FormFactor string `json:"form_factor" jsonschema:"pattern=^(standard|micro|mini|nano)"`
+	NeedKeyboard bool `json:"need_keyboard"`
+}
+
 func (p StringOrNull) OneOf() []reflect.StructField {
 	strings, _ := reflect.TypeOf(p).FieldByName("String")
 	return []reflect.StructField{
 		strings,
 		reflect.StructField{Type: nil},
+	}
+}
+
+func (h Hardware) AndOneOf() []reflect.StructField {
+	return []reflect.StructField{
+		reflect.StructField{Type: reflect.TypeOf(Laptop{})},
+		reflect.StructField{Type: reflect.TypeOf(Hardware{})},
 	}
 }
 


### PR DESCRIPTION
This reverts my change and the optional string type implementation to better capture the two cases depicted in:
https://spacetelescope.github.io/understanding-json-schema/reference/combining.html#oneof 

*oneOf used exclusively*:
```
{
  "oneOf": [
    { "type": "number", "multipleOf": 5 },
    { "type": "number", "multipleOf": 3 }
  ]
}
```

*oneOf used to capture common cases*:
```
{
  "type": "number",
  "oneOf": [
    { "multipleOf": 5 },
    { "multipleOf": 3 }
  ]
}
```