### PR TITLE
[DGODP-229] Implement enum

### DIFF
--- a/fixtures/allow_additional_props.json
+++ b/fixtures/allow_additional_props.json
@@ -85,6 +85,26 @@
             "binaryEncoding": "base64"
           }
         },
+        "secret_number": {
+          "enum": [
+            9,
+            30,
+            28,
+            52
+          ],
+          "type": "integer"
+        },
+        "sex": {
+          "enum": [
+            "male",
+            "female",
+            "neither",
+            "whatever",
+            "other",
+            "not applicable"
+          ],
+          "type": "string"
+        },
         "some_base_property": {
           "type": "integer"
         },

--- a/fixtures/defaults.json
+++ b/fixtures/defaults.json
@@ -32,20 +32,20 @@
         "TestFlag": {
           "type": "boolean"
         },
-        "age":{
+        "age": {
           "maximum": 120,
-          "minimum": 18,
           "exclusiveMaximum": true,
+          "minimum": 18,
           "exclusiveMinimum": true,
           "type": "integer"
-        },  
-        "email": {
-          "type": "string",
-          "format": "email"
         },
         "birth_date": {
           "type": "string",
           "format": "date-time"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
         },
         "feeling": {
           "oneOf": [
@@ -71,9 +71,9 @@
           "type": "integer"
         },
         "name": {
-          "type": "string",
           "maxLength": 20,
-          "minLength": 1
+          "minLength": 1,
+          "type": "string"
         },
         "network_address": {
           "type": "string",
@@ -84,6 +84,26 @@
           "media": {
             "binaryEncoding": "base64"
           }
+        },
+        "secret_number": {
+          "enum": [
+            9,
+            30,
+            28,
+            52
+          ],
+          "type": "integer"
+        },
+        "sex": {
+          "enum": [
+            "male",
+            "female",
+            "neither",
+            "whatever",
+            "other",
+            "not applicable"
+          ],
+          "type": "string"
         },
         "some_base_property": {
           "type": "integer"

--- a/fixtures/defaults_expanded_toplevel.json
+++ b/fixtures/defaults_expanded_toplevel.json
@@ -70,6 +70,26 @@
         "binaryEncoding": "base64"
       }
     },
+    "secret_number": {
+      "enum": [
+        9,
+        30,
+        28,
+        52
+      ],
+      "type": "integer"
+    },
+    "sex": {
+      "enum": [
+        "male",
+        "female",
+        "neither",
+        "whatever",
+        "other",
+        "not applicable"
+      ],
+      "type": "string"
+    },
     "some_base_property": {
       "type": "integer"
     },

--- a/fixtures/required_from_jsontags.json
+++ b/fixtures/required_from_jsontags.json
@@ -81,6 +81,26 @@
             "binaryEncoding": "base64"
           }
         },
+        "secret_number": {
+          "enum": [
+            9,
+            30,
+            28,
+            52
+          ],
+          "type": "integer"
+        },
+        "sex": {
+          "enum": [
+            "male",
+            "female",
+            "neither",
+            "whatever",
+            "other",
+            "not applicable"
+          ],
+          "type": "string"
+        },
         "some_base_property": {
           "type": "integer"
         },

--- a/reflect.go
+++ b/reflect.go
@@ -360,6 +360,14 @@ func (t *Type) stringKeywords(tags []string) {
 			case "maxLength":
 				i, _ := strconv.Atoi(val)
 				t.MaxLength = i
+			case "enum":
+				enum := strings.Split(val, "|")
+				s := make([]interface{}, len(enum))
+				for k, v := range enum {
+					s[k] = v
+				}
+
+				t.Enum = s
 			case "format":
 				switch val {
 				case "date-time", "email", "hostname", "ipv4", "ipv6", "uri":
@@ -401,6 +409,14 @@ func (t *Type) numbericKeywords(tags []string) {
 			case "exclusiveMinimum":
 				b, _ := strconv.ParseBool(val)
 				t.ExclusiveMinimum = b
+			case "enum":
+				enum := strings.Split(val, "|")
+				s := make([]interface{}, len(enum))
+				for k, v := range enum {
+					s[k], _ = strconv.Atoi(v)
+				}
+
+				t.Enum = s
 			}
 		}
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -68,6 +68,9 @@ type TestUser struct {
 	Feeling ProtoEnum `json:"feeling,omitempty"`
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
+
+	SecretNumber int  `json:"secret_number,omitempty" jsonschema:"enum=9|30|28|52"`
+	Sex		string    `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
 }
 
 var schemaGenerationTests = []struct {
@@ -99,7 +102,7 @@ func TestSchemaGeneration(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(actualSchema, expectedSchema) {
-				actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
+				actualJSON, err := json.MarshalIndent(actualSchema, "", " ")
 				if err != nil {
 					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
 					return

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -101,16 +101,67 @@ func TestSchemaGeneration(t *testing.T) {
 				return
 			}
 
+			expectedSchema.Type = reconcileTypes(expectedSchema.Type)
+			expectedSchema.Definitions = reconcileEnumTypes(expectedSchema.Definitions)
+
 			if !reflect.DeepEqual(actualSchema, expectedSchema) {
-				actualJSON, err := json.MarshalIndent(actualSchema, "", " ")
+				actualJSON, err := json.Marshal(actualSchema)
 				if err != nil {
 					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
 					return
 				}
-				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
+
+				expectedJSON, err := json.Marshal(expectedSchema)
+				if err != nil {
+					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", expectedJSON, err)
+					return
+				}
+
+				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, expectedJSON, actualJSON)
 			}
 		})
 	}
+}
+
+// The marshaling of json into interface{} results in a mismatch when we DeepEqual the expected/actual schemas for enum
+// This coerces all float64 enums back to int
+func reconcileTypes(t *Type) *Type {
+	t.Definitions = reconcileEnumTypes(t.Definitions)
+	t.Properties = convertEnum(t.Properties)
+
+	return t
+}
+
+func reconcileEnumTypes(definitions Definitions) Definitions {
+	mismatched := convertDefinitions(definitions)
+	converted :=  convertEnum(mismatched)
+
+	return Definitions(converted)
+}
+
+func convertDefinitions(definitions Definitions) map[string]*Type {
+	return map[string]*Type(definitions)
+}
+
+func convertEnum(definitions map[string]*Type) map[string]*Type {
+	for _, v := range definitions {
+		if len(v.Definitions) > 0 {
+			d := convertDefinitions(v.Definitions)
+			v.Definitions = convertEnum(d)
+		}
+
+		if len(v.Properties) > 0 {
+			v.Properties = convertEnum(v.Properties)
+		}
+
+		if len(v.Enum) > 0 && (reflect.TypeOf(v.Enum[0]).Kind() == reflect.Float64) {
+			for idx, val := range v.Enum {
+				v.Enum[idx] = int(val.(float64))
+			}
+		}
+	}
+
+	return definitions
 }
 
 type TestUserOneOf struct {
@@ -210,3 +261,4 @@ func TestOneOfSchemaGeneration(t *testing.T) {
 	}
 
 }
+


### PR DESCRIPTION
This implements `enum`

Usage:

```
type Human struct {
       Sex string `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
}
```

Generates:

```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "$ref": "#/definitions/Human",
  "definitions": {
    "Human": {
      "properties": {
        "sex": {
          "enum": [
            "male",
            "female",
            "neither",
            "whatever",
            "other",
            "not applicable"
          ],
          "type": "string"
        }
      },
      "type": "object"
    }
  }
}
```

