### PR TITLE
[DGODP-360] Investigate about possible implementations of IF/THEN/ELSE conditional in jsonschema

### DIFF
--- a/fixtures/if_then_else.json
+++ b/fixtures/if_then_else.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/Application",
+  "definitions": {
+    "Application": {
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "if": {
+        "properties": {
+          "type": {
+            "enum": [
+              "web"
+            ]
+          }
+        }
+      },
+      "then": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$ref": "#/definitions/WebApp"
+      },
+      "else": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$ref": "#/definitions/MobileApp"
+      }
+    },
+    "MobileApp": {
+      "required": [
+        "device"
+      ],
+      "properties": {
+        "device": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "WebApp": {
+      "required": [
+        "browser"
+      ],
+      "properties": {
+        "browser": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect.go
+++ b/reflect.go
@@ -28,6 +28,7 @@ type Schema struct {
 	Definitions Definitions `json:"definitions,omitempty"`
 }
 
+// SchemaCondition holds data for if/then/else jsonschema statements
 type SchemaCondition struct {
 	If   reflect.StructField
 	Then interface{}
@@ -185,6 +186,12 @@ type oneOf interface {
 	OneOf() []reflect.StructField
 }
 
+//Implement IfThenElse() when condition needs to be used
+// {
+//    "if": { "properties": { "power": { "minimum": 9000 } } },
+//    "then": { "required": [ "disbelief" ] },
+//    "else": { "required": [ "confidence" ] }
+// }
 type ifThenElse interface {
 	IfThenElse() SchemaCondition
 }
@@ -339,8 +346,12 @@ func (r *Reflector) reflectCondition(definitions Definitions, s SchemaCondition,
 	}
 
 	t.If = condition
-	t.Then = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Then))
-	t.Else = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Else))
+	if reflect.TypeOf(s.Then) != nil {
+		t.Then = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Then))
+	}
+	if reflect.TypeOf(s.Else) != nil {
+		t.Else = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Else))
+	}
 }
 
 func (r *Reflector) reflectStructFields(st *Type, definitions Definitions, t reflect.Type) {

--- a/reflect.go
+++ b/reflect.go
@@ -335,22 +335,22 @@ func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type) *Type
 	}
 }
 
-func (r *Reflector) reflectCondition(definitions Definitions, s SchemaCondition, t *Type) {
+func (r *Reflector) reflectCondition(definitions Definitions, sc SchemaCondition, t *Type) {
 	conditionSchema := Type{}
-	conditionSchema.structKeywordsFromTags(s.If)
+	conditionSchema.structKeywordsFromTags(sc.If)
 
 	condition := &Type{
 		Properties: map[string]*Type{
-			s.If.Name: &conditionSchema,
+			sc.If.Tag.Get("json"): &conditionSchema,
 		},
 	}
 
 	t.If = condition
-	if reflect.TypeOf(s.Then) != nil {
-		t.Then = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Then))
+	if reflect.TypeOf(sc.Then) != nil {
+		t.Then = r.reflectTypeToSchema(definitions, reflect.TypeOf(sc.Then))
 	}
-	if reflect.TypeOf(s.Else) != nil {
-		t.Else = r.reflectTypeToSchema(definitions, reflect.TypeOf(s.Else))
+	if reflect.TypeOf(sc.Else) != nil {
+		t.Else = r.reflectTypeToSchema(definitions, reflect.TypeOf(sc.Else))
 	}
 }
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -269,6 +269,10 @@ type Application struct {
 	Type string `json:"type" jsonschema:"required"`
 }
 
+type ApplicationValidation struct {
+	Type string `json:"type" jsonschema:"enum=web"`
+}
+
 type WebApp struct {
 	Browser string `json:"browser"`
 }
@@ -278,11 +282,9 @@ type MobileApp struct {
 }
 
 func (app Application) IfThenElse() SchemaCondition {
+	conditionField, _ := reflect.TypeOf(ApplicationValidation{}).FieldByName("Type")
 	return SchemaCondition{
-		If: reflect.StructField{
-			Name: "type",
-			Tag:  `jsonschema:"enum=web"`,
-		},
+		If: conditionField,
 		Then: WebApp{},
 		Else: MobileApp{},
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -71,8 +71,8 @@ type TestUser struct {
 	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
 	Email   string    `json:"email" jsonschema:"format=email"`
 
-	SecretNumber int  `json:"secret_number,omitempty" jsonschema:"enum=9|30|28|52"`
-	Sex		string    `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
+	SecretNumber int    `json:"secret_number,omitempty" jsonschema:"enum=9|30|28|52"`
+	Sex          string `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
 }
 
 var schemaGenerationTests = []struct {
@@ -136,7 +136,7 @@ func reconcileTypes(t *Type) *Type {
 
 func reconcileEnumTypes(definitions Definitions) Definitions {
 	mismatched := convertDefinitions(definitions)
-	converted :=  convertEnum(mismatched)
+	converted := convertEnum(mismatched)
 
 	return Definitions(converted)
 }
@@ -187,9 +187,9 @@ type Tester struct {
 
 // Developer  struct
 type Developer struct {
-	Experience StringOrNull `json:"experience" jsonschema:"minLength=1"`
-	Language   StringOrNull `json:"language" jsonschema:"required,pattern=\\S+"`
-	HardwareChoice Hardware  `json:"hardware"`
+	Experience     StringOrNull `json:"experience" jsonschema:"minLength=1"`
+	Language       StringOrNull `json:"language" jsonschema:"required,pattern=\\S+"`
+	HardwareChoice Hardware     `json:"hardware"`
 }
 
 type StringOrNull struct {
@@ -198,18 +198,18 @@ type StringOrNull struct {
 }
 
 type Hardware struct {
-	Brand string `json:"brand" jsonschema:"required,notEmpty"`
-	Memory int `json:"memory" jsonschema:"required"`
+	Brand  string `json:"brand" jsonschema:"required,notEmpty"`
+	Memory int    `json:"memory" jsonschema:"required"`
 }
 
 type Laptop struct {
-	Brand string `json:"brand" jsonschema:"pattern=^(apple|lenovo|dell)$"`
-	NeedTouchScreen bool `json:"need_touchscreen"`
+	Brand           string `json:"brand" jsonschema:"pattern=^(apple|lenovo|dell)$"`
+	NeedTouchScreen bool   `json:"need_touchscreen"`
 }
 
 type Desktop struct {
-	FormFactor string `json:"form_factor" jsonschema:"pattern=^(standard|micro|mini|nano)"`
-	NeedKeyboard bool `json:"need_keyboard"`
+	FormFactor   string `json:"form_factor" jsonschema:"pattern=^(standard|micro|mini|nano)"`
+	NeedKeyboard bool   `json:"need_keyboard"`
 }
 
 func (p StringOrNull) OneOf() []reflect.StructField {
@@ -233,6 +233,7 @@ var oneOfSchemaGenerationTests = []struct {
 }{
 	{&Reflector{}, "fixtures/test_one_of_default.json"},
 }
+
 func TestOneOfSchemaGeneration(t *testing.T) {
 	for _, tt := range oneOfSchemaGenerationTests {
 		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
@@ -264,3 +265,62 @@ func TestOneOfSchemaGeneration(t *testing.T) {
 
 }
 
+type Application struct {
+	Type string `json:"type" jsonschema:"required"`
+}
+
+type WebApp struct {
+	Browser string `json:"browser"`
+}
+
+type MobileApp struct {
+	Device string `json:"device"`
+}
+
+func (app Application) IfThenElse() SchemaCondition {
+	return SchemaCondition{
+		If: reflect.StructField{
+			Name: "type",
+			Tag:  `jsonschema:"enum=web"`,
+		},
+		Then: WebApp{},
+		Else: MobileApp{},
+	}
+}
+
+var ifThenElseSchemaGenerationTests = []struct {
+	reflector *Reflector
+	fixture   string
+}{
+	{&Reflector{}, "fixtures/if_then_else.json"},
+}
+
+func TestIfThenElseSchemaGeneration(t *testing.T) {
+	for _, tt := range ifThenElseSchemaGenerationTests {
+		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
+		t.Run(name, func(t *testing.T) {
+			f, err := ioutil.ReadFile(tt.fixture)
+			if err != nil {
+				t.Errorf("ioutil.ReadAll(%s): %s", tt.fixture, err)
+				return
+			}
+
+			actualSchema := tt.reflector.Reflect(Application{})
+			expectedSchema := &Schema{}
+
+			if err := json.Unmarshal(f, expectedSchema); err != nil {
+				t.Errorf("json.Unmarshal(%s, %v): %s", tt.fixture, expectedSchema, err)
+				return
+			}
+
+			if !reflect.DeepEqual(actualSchema, expectedSchema) {
+				actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
+				if err != nil {
+					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
+					return
+				}
+				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 - if/then/else jsonschema draft v7 implementation ([docs](http://json-schema.org/draft-07/json-schema-validation.html#rfc.section.6.6))

Structure that wants to generate schema, containing condition statement, must implement `ifThenElse` interface method `IfThenElse()` which returns `SchemaCondition` structure.

`SchemaCondition` structure contains 3 fields:
 - `If` - `StructField` that defines condition JSON schema
 - `Then` - any type, that can be converted to JSON schema. If validation on **if** statements succeed, then validation on **then** subschema must also be succesfull.
 - `Else` - any type, that can be converted to JSON schema. If validation on **if** statements fails, then validation on **then** subschema must be succesfull.

If `Then` or `Else` part is missing, validation would be succesfull.