### PR TITLE
Allow jsonschema tags to be overriden

### DIFF
--- a/fixtures/override_jsonschema_tag.json
+++ b/fixtures/override_jsonschema_tag.json
@@ -1,0 +1,112 @@
+{
+  "oneOf": [
+    {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/Tester"
+    },
+    {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "$ref": "#/definitions/Developer"
+    }
+  ],
+  "definitions": {
+    "Developer": {
+      "required": [
+        "experience",
+        "language",
+        "hardware"
+      ],
+      "properties": {
+        "experience": {
+          "minLength": 1,
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hardware": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/Hardware"
+        },
+        "language": {
+          "pattern": "\\S+",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Hardware": {
+      "required": [
+        "brand",
+        "memory"
+      ],
+      "properties": {
+        "brand": {
+          "enum": ["microsoft", "apple", "lenovo", "dell"],
+          "type": "string"
+        },
+        "memory": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Laptop"
+        },
+        {
+          "$ref": "#/definitions/Hardware"
+        }
+      ]
+    },
+    "Laptop": {
+      "required": [
+        "brand",
+        "need_touchscreen"
+      ],
+      "properties": {
+        "brand": {
+          "pattern": "^(apple|lenovo|dell)$",
+          "type": "string"
+        },
+        "need_touchscreen": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Tester": {
+      "required": [
+        "experience"
+      ],
+      "properties": {
+        "experience": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/reflect_application_test.go
+++ b/reflect_application_test.go
@@ -1,0 +1,29 @@
+package jsonschema
+
+import "reflect"
+
+type Application struct {
+	Type string `json:"type" jsonschema:"required"`
+}
+
+type ApplicationValidation struct {
+	Type string `json:"type" jsonschema:"enum=web"`
+}
+
+type WebApp struct {
+	Browser string `json:"browser"`
+}
+
+type MobileApp struct {
+	Device string `json:"device"`
+}
+
+func (app Application) IfThenElse() SchemaCondition {
+	conditionField, _ := reflect.TypeOf(ApplicationValidation{}).FieldByName("Type")
+	return SchemaCondition{
+		If:   conditionField,
+		Then: WebApp{},
+		Else: MobileApp{},
+	}
+}
+

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,118 +1,72 @@
 package jsonschema
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"net"
-	"net/url"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
-	"time"
-	"bytes"
 )
 
-type GrandfatherType struct {
-	FamilyName string `json:"family_name" jsonschema:"required"`
-}
-
-type SomeBaseType struct {
-	SomeBaseProperty int `json:"some_base_property"`
-	// The jsonschema required tag is nonsensical for private and ignored properties.
-	// Their presence here tests that the fields *will not* be required in the output
-	// schema, even if they are tagged required.
-	somePrivateBaseProperty   string          `json:"i_am_private" jsonschema:"required"`
-	SomeIgnoredBaseProperty   string          `json:"-" jsonschema:"required"`
-	SomeSchemaIgnoredProperty string          `jsonschema:"-,required"`
-	Grandfather               GrandfatherType `json:"grand"`
-
-	SomeUntaggedBaseProperty           bool `jsonschema:"required"`
-	someUnexportedUntaggedBaseProperty bool
-}
-
-type nonExported struct {
-	PublicNonExported  int
-	privateNonExported int
-}
-
-type ProtoEnum int32
-
-func (ProtoEnum) EnumDescriptor() ([]byte, []int) { return []byte(nil), []int{0} }
-
-const (
-	Unset ProtoEnum = iota
-	Great
-)
-
-type TestUser struct {
-	SomeBaseType
-	nonExported
-
-	ID       int                    `json:"id" jsonschema:"required"`
-	Name     string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20"`
-	Nickname *string                `json:"nickname" jsonschema:"required,allowNull"`
-	Friends  []int                  `json:"friends,omitempty"`
-	Tags     map[string]interface{} `json:"tags,omitempty"`
-	Keywords map[string]string      `json:"keywords,omitempty"`
-
-	TestFlag       bool
-	IgnoredCounter int `json:"-"`
-
-	// Tests for RFC draft-wright-json-schema-validation-00, section 7.3
-	BirthDate time.Time `json:"birth_date,omitempty"`
-	Website   url.URL   `json:"website,omitempty"`
-	IPAddress net.IP    `json:"network_address,omitempty"`
-
-	// Tests for RFC draft-wright-json-schema-hyperschema-00, section 4
-	Photo []byte `json:"photo,omitempty" jsonschema:"required"`
-
-	// Tests for jsonpb enum support
-	Feeling ProtoEnum `json:"feeling,omitempty"`
-	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
-	Email   string    `json:"email" jsonschema:"format=email"`
-
-	SecretNumber int    `json:"secret_number,omitempty" jsonschema:"enum=9|30|28|52"`
-	Sex          string `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
-	SecretFloatNumber float64  `json:"secret_float_number,omitempty" jsonschema:"enum=9.1|30.2|28.4|52.9"`
-}
-
-var schemaGenerationTests = []struct {
+type testSet struct {
 	reflector *Reflector
 	fixture   string
-}{
-	{&Reflector{}, "fixtures/defaults.json"},
-	{&Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json"},
-	{&Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json"},
-	{&Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json"},
+	actual    interface{}
+}
+
+var schemaGenerationTests = []testSet{
+	{&Reflector{}, "fixtures/defaults.json", TestUser{}},
+	{&Reflector{AllowAdditionalProperties: true}, "fixtures/allow_additional_props.json", TestUser{}},
+	{&Reflector{RequiredFromJSONSchemaTags: true}, "fixtures/required_from_jsontags.json", TestUser{}},
+	{&Reflector{ExpandedStruct: true}, "fixtures/defaults_expanded_toplevel.json", TestUser{}},
+	{&Reflector{}, "fixtures/test_one_of_default.json", TestUserOneOf{}},
+	{&Reflector{}, "fixtures/if_then_else.json", Application{}},
 }
 
 func TestSchemaGeneration(t *testing.T) {
 	for _, tt := range schemaGenerationTests {
-		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
-		t.Run(name, func(t *testing.T) {
-			f, err := ioutil.ReadFile(tt.fixture)
-			if err != nil {
-				t.Errorf("ioutil.ReadAll(%s): %s", tt.fixture, err)
-				return
-			}
-
-			actualSchema := tt.reflector.Reflect(&TestUser{})
-
-			actualJSON, err := json.Marshal(actualSchema)
-			if err != nil {
-				t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualJSON, err)
-				return
-			}
-			actualJSON = sanitizeExpectedJson(actualJSON)
-			cleanExpectedJSON := sanitizeExpectedJson(f)
-
-			if !bytes.Equal(cleanExpectedJSON,actualJSON) {
-
-				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, cleanExpectedJSON, actualJSON)
-			}
-		})
+		runTests(t, tt)
 	}
+}
+
+func TestOverrides(t *testing.T) {
+	override := GetSchemaTagOverride()
+	override.Set(Hardware{}, "Brand", "enum=microsoft|apple|lenovo|dell")
+
+	test := testSet{
+		reflector: &Reflector{Overrides: override},
+		fixture:   "fixtures/override_jsonschema_tag.json",
+		actual:    TestUserOneOf{},
+	}
+
+	runTests(t, test)
+}
+
+func runTests(t *testing.T, tt testSet) {
+	name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
+	t.Run(name, func(t *testing.T) {
+		f, err := ioutil.ReadFile(tt.fixture)
+		if err != nil {
+			t.Errorf("ioutil.ReadAll(%s): %s", tt.fixture, err)
+			return
+		}
+
+		actualSchema := tt.reflector.Reflect(tt.actual)
+
+		actualJSON, err := json.Marshal(actualSchema)
+		if err != nil {
+			t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualJSON, err)
+			return
+		}
+		actualJSON = sanitizeExpectedJson(actualJSON)
+		cleanExpectedJSON := sanitizeExpectedJson(f)
+
+		if !bytes.Equal(cleanExpectedJSON, actualJSON) {
+
+			t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, cleanExpectedJSON, actualJSON)
+		}
+	})
 }
 
 func sanitizeExpectedJson(expectedJSON []byte) []byte {
@@ -120,165 +74,4 @@ func sanitizeExpectedJson(expectedJSON []byte) []byte {
 	json.Unmarshal(expectedJSON, &js)
 	clean, _ := json.Marshal(js)
 	return clean
-}
-
-type TestUserOneOf struct {
-	Tester    Tester    `json:"tester" jsonschema:"required"`
-	Developer Developer `json:"developer" jsonschema:"required"`
-}
-
-func (user TestUserOneOf) OneOf() []reflect.StructField {
-	tester, _ := reflect.TypeOf(user).FieldByName("Tester")
-	developer, _ := reflect.TypeOf(user).FieldByName("Developer")
-	return []reflect.StructField{
-		tester,
-		developer,
-	}
-}
-
-// Tester  struct
-type Tester struct {
-	Experience StringOrNull `json:"experience"`
-}
-
-// Developer  struct
-type Developer struct {
-	Experience     StringOrNull `json:"experience" jsonschema:"minLength=1"`
-	Language       StringOrNull `json:"language" jsonschema:"required,pattern=\\S+"`
-	HardwareChoice Hardware     `json:"hardware"`
-}
-
-type StringOrNull struct {
-	String string
-	IsNull bool
-}
-
-type Hardware struct {
-	Brand  string `json:"brand" jsonschema:"required,notEmpty"`
-	Memory int    `json:"memory" jsonschema:"required"`
-}
-
-type Laptop struct {
-	Brand           string `json:"brand" jsonschema:"pattern=^(apple|lenovo|dell)$"`
-	NeedTouchScreen bool   `json:"need_touchscreen"`
-}
-
-type Desktop struct {
-	FormFactor   string `json:"form_factor" jsonschema:"pattern=^(standard|micro|mini|nano)"`
-	NeedKeyboard bool   `json:"need_keyboard"`
-}
-
-func (p StringOrNull) OneOf() []reflect.StructField {
-	strings, _ := reflect.TypeOf(p).FieldByName("String")
-	return []reflect.StructField{
-		strings,
-		reflect.StructField{Type: nil},
-	}
-}
-
-func (h Hardware) AndOneOf() []reflect.StructField {
-	return []reflect.StructField{
-		reflect.StructField{Type: reflect.TypeOf(Laptop{})},
-		reflect.StructField{Type: reflect.TypeOf(Hardware{})},
-	}
-}
-
-var oneOfSchemaGenerationTests = []struct {
-	reflector *Reflector
-	fixture   string
-}{
-	{&Reflector{}, "fixtures/test_one_of_default.json"},
-}
-
-func TestOneOfSchemaGeneration(t *testing.T) {
-	for _, tt := range oneOfSchemaGenerationTests {
-		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
-		t.Run(name, func(t *testing.T) {
-			f, err := ioutil.ReadFile(tt.fixture)
-			if err != nil {
-				t.Errorf("ioutil.ReadAll(%s): %s", tt.fixture, err)
-				return
-			}
-
-			actualSchema := tt.reflector.Reflect(TestUserOneOf{})
-			expectedSchema := &Schema{}
-
-			if err := json.Unmarshal(f, expectedSchema); err != nil {
-				t.Errorf("json.Unmarshal(%s, %v): %s", tt.fixture, expectedSchema, err)
-				return
-			}
-
-			if !reflect.DeepEqual(actualSchema, expectedSchema) {
-				actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
-				if err != nil {
-					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
-					return
-				}
-				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
-			}
-		})
-	}
-
-}
-
-type Application struct {
-	Type string `json:"type" jsonschema:"required"`
-}
-
-type ApplicationValidation struct {
-	Type string `json:"type" jsonschema:"enum=web"`
-}
-
-type WebApp struct {
-	Browser string `json:"browser"`
-}
-
-type MobileApp struct {
-	Device string `json:"device"`
-}
-
-func (app Application) IfThenElse() SchemaCondition {
-	conditionField, _ := reflect.TypeOf(ApplicationValidation{}).FieldByName("Type")
-	return SchemaCondition{
-		If: conditionField,
-		Then: WebApp{},
-		Else: MobileApp{},
-	}
-}
-
-var ifThenElseSchemaGenerationTests = []struct {
-	reflector *Reflector
-	fixture   string
-}{
-	{&Reflector{}, "fixtures/if_then_else.json"},
-}
-
-func TestIfThenElseSchemaGeneration(t *testing.T) {
-	for _, tt := range ifThenElseSchemaGenerationTests {
-		name := strings.TrimSuffix(filepath.Base(tt.fixture), ".json")
-		t.Run(name, func(t *testing.T) {
-			f, err := ioutil.ReadFile(tt.fixture)
-			if err != nil {
-				t.Errorf("ioutil.ReadAll(%s): %s", tt.fixture, err)
-				return
-			}
-
-			actualSchema := tt.reflector.Reflect(Application{})
-			expectedSchema := &Schema{}
-
-			if err := json.Unmarshal(f, expectedSchema); err != nil {
-				t.Errorf("json.Unmarshal(%s, %v): %s", tt.fixture, expectedSchema, err)
-				return
-			}
-
-			if !reflect.DeepEqual(actualSchema, expectedSchema) {
-				actualJSON, err := json.MarshalIndent(actualSchema, "", "  ")
-				if err != nil {
-					t.Errorf("json.MarshalIndent(%v, \"\", \"  \"): %v", actualSchema, err)
-					return
-				}
-				t.Errorf("reflector %+v wanted schema %s, got %s", tt.reflector, f, actualJSON)
-			}
-		})
-	}
 }

--- a/reflect_test_user_one_of_test.go
+++ b/reflect_test_user_one_of_test.go
@@ -1,0 +1,64 @@
+package jsonschema
+
+import "reflect"
+
+type TestUserOneOf struct {
+	Tester    Tester    `json:"tester" jsonschema:"required"`
+	Developer Developer `json:"developer" jsonschema:"required"`
+}
+
+func (user TestUserOneOf) OneOf() []reflect.StructField {
+	tester, _ := reflect.TypeOf(user).FieldByName("Tester")
+	developer, _ := reflect.TypeOf(user).FieldByName("Developer")
+	return []reflect.StructField{
+		tester,
+		developer,
+	}
+}
+
+// Tester  struct
+type Tester struct {
+	Experience StringOrNull `json:"experience"`
+}
+
+// Developer  struct
+type Developer struct {
+	Experience     StringOrNull `json:"experience" jsonschema:"minLength=1"`
+	Language       StringOrNull `json:"language" jsonschema:"required,pattern=\\S+"`
+	HardwareChoice Hardware     `json:"hardware"`
+}
+
+type StringOrNull struct {
+	String string
+	IsNull bool
+}
+
+type Hardware struct {
+	Brand  string `json:"brand" jsonschema:"required,notEmpty"`
+	Memory int    `json:"memory" jsonschema:"required"`
+}
+
+type Laptop struct {
+	Brand           string `json:"brand" jsonschema:"pattern=^(apple|lenovo|dell)$"`
+	NeedTouchScreen bool   `json:"need_touchscreen"`
+}
+
+type Desktop struct {
+	FormFactor   string `json:"form_factor" jsonschema:"pattern=^(standard|micro|mini|nano)"`
+	NeedKeyboard bool   `json:"need_keyboard"`
+}
+
+func (p StringOrNull) OneOf() []reflect.StructField {
+	strings, _ := reflect.TypeOf(p).FieldByName("String")
+	return []reflect.StructField{
+		strings,
+		reflect.StructField{Type: nil},
+	}
+}
+
+func (h Hardware) AndOneOf() []reflect.StructField {
+	return []reflect.StructField{
+		reflect.StructField{Type: reflect.TypeOf(Laptop{})},
+		reflect.StructField{Type: reflect.TypeOf(Hardware{})},
+	}
+}

--- a/reflect_test_user_test.go
+++ b/reflect_test_user_test.go
@@ -1,0 +1,71 @@
+package jsonschema
+
+import (
+	"net"
+	"net/url"
+	"time"
+)
+
+type GrandfatherType struct {
+	FamilyName string `json:"family_name" jsonschema:"required"`
+}
+
+type SomeBaseType struct {
+	SomeBaseProperty int `json:"some_base_property"`
+	// The jsonschema required tag is nonsensical for private and ignored properties.
+	// Their presence here tests that the fields *will not* be required in the output
+	// schema, even if they are tagged required.
+	somePrivateBaseProperty   string          `json:"i_am_private" jsonschema:"required"`
+	SomeIgnoredBaseProperty   string          `json:"-" jsonschema:"required"`
+	SomeSchemaIgnoredProperty string          `jsonschema:"-,required"`
+	Grandfather               GrandfatherType `json:"grand"`
+
+	SomeUntaggedBaseProperty           bool `jsonschema:"required"`
+	someUnexportedUntaggedBaseProperty bool
+}
+
+type nonExported struct {
+	PublicNonExported  int
+	privateNonExported int
+}
+
+type ProtoEnum int32
+
+func (ProtoEnum) EnumDescriptor() ([]byte, []int) { return []byte(nil), []int{0} }
+
+const (
+	Unset ProtoEnum = iota
+	Great
+)
+
+type TestUser struct {
+	SomeBaseType
+	nonExported
+
+	ID       int                    `json:"id" jsonschema:"required"`
+	Name     string                 `json:"name" jsonschema:"required,minLength=1,maxLength=20"`
+	Nickname *string                `json:"nickname" jsonschema:"required,allowNull"`
+	Friends  []int                  `json:"friends,omitempty"`
+	Tags     map[string]interface{} `json:"tags,omitempty"`
+	Keywords map[string]string      `json:"keywords,omitempty"`
+
+	TestFlag       bool
+	IgnoredCounter int `json:"-"`
+
+	// Tests for RFC draft-wright-json-schema-validation-00, section 7.3
+	BirthDate time.Time `json:"birth_date,omitempty"`
+	Website   url.URL   `json:"website,omitempty"`
+	IPAddress net.IP    `json:"network_address,omitempty"`
+
+	// Tests for RFC draft-wright-json-schema-hyperschema-00, section 4
+	Photo []byte `json:"photo,omitempty" jsonschema:"required"`
+
+	// Tests for jsonpb enum support
+	Feeling ProtoEnum `json:"feeling,omitempty"`
+	Age     int       `json:"age" jsonschema:"minimum=18,maximum=120,exclusiveMaximum=true,exclusiveMinimum=true"`
+	Email   string    `json:"email" jsonschema:"format=email"`
+
+	SecretNumber      int     `json:"secret_number,omitempty" jsonschema:"enum=9|30|28|52"`
+	Sex               string  `json:"sex,omitempty" jsonschema:"enum=male|female|neither|whatever|other|not applicable"`
+	SecretFloatNumber float64 `json:"secret_float_number,omitempty" jsonschema:"enum=9.1|30.2|28.4|52.9"`
+}

--- a/schema_tag_override.go
+++ b/schema_tag_override.go
@@ -1,0 +1,64 @@
+package jsonschema
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// SchemaTagOverride is a mechanism to allow jsonschema tag overrides
+type SchemaTagOverride interface {
+	// Set should be given:
+	// targetStruct - struct that contains the field to be overridden
+	// targetField - name of the field that is to be overridden
+	// tag - the provided jsonschema tag
+	Set(targetStruct interface{}, targetField string, tag string) error
+	// Get is used by this library to retrieve overrides
+	Get(targetStructType reflect.Type, targetField string) string
+}
+
+// GetSchemaTagOverride returns initialized SchemaTagOverride
+func GetSchemaTagOverride() SchemaTagOverride {
+	c := make(map[reflect.Type]map[string]string)
+
+	return &overrides{config: c}
+}
+
+type overrides struct {
+	config map[reflect.Type]map[string]string
+}
+
+// Set adds a jsonschema tag override to internal map
+func (o *overrides) Set(targetStruct interface{}, targetField string, tag string) error {
+	ts := reflect.TypeOf(targetStruct)
+
+	if k := ts.Kind(); k != reflect.Struct {
+		return fmt.Errorf("expecting struct, got %s instead", reflect.Kind(k))
+	}
+
+	if _, ok := ts.FieldByName(targetField); !ok {
+		return fmt.Errorf("targetStruct %s does not have field %s", ts.Name(), targetField)
+	}
+
+	if o.config[ts] != nil {
+		o.config[ts][targetField] = tag
+
+		return nil
+	}
+
+	o.config[ts] = map[string]string{targetField: tag}
+
+	return nil
+}
+
+// Get retrieves tags from internal map
+func (o *overrides) Get(targetStructType reflect.Type, targetField string) string {
+	if targetStructType.Kind() != reflect.Struct {
+		return ""
+	}
+
+	if o.config[targetStructType] == nil {
+		return ""
+	}
+
+	return o.config[targetStructType][targetField]
+}

--- a/schema_tag_override_test.go
+++ b/schema_tag_override_test.go
@@ -1,0 +1,94 @@
+package jsonschema
+
+import (
+	"reflect"
+	"testing"
+)
+
+type Human struct {
+	Name   string
+	Sex    string
+	age    int
+	secret Alien
+}
+
+type Alien struct {
+	Blerp   string
+	bloop   float64
+	molting bool
+}
+
+func TestSchemaTagOverrideSet(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	ok := sto.Set(Human{}, "Name", "required")
+
+	if ok != nil {
+		t.Errorf("failed to set field %s due to %s", "Name", ok)
+	}
+}
+
+func TestSchemaTagOverrideSetPointer(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	ok := sto.Set(&Human{}, "Name", "required")
+
+	if ok == nil {
+		t.Error("failed to return error when given non-struct as target struct")
+	}
+}
+
+func TestSchemaTagOverrideSetErrorForInvalidField(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	ok := sto.Set(Human{}, "name", "required")
+
+	if ok == nil {
+		t.Errorf("was able to set field %s even though it doesn't exist on target struct", "name")
+	}
+}
+
+func TestGetSchemaTagOverrideGet(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	sto.Set(Human{}, "Name", "required")
+
+	tag := sto.Get(reflect.TypeOf(Human{}), "Name")
+
+	if tag != "required" {
+		t.Errorf("did not receive expected tag override from Name field, got %s instead", tag)
+	}
+}
+
+func TestGetSchemaTagOverrideGetNonExistentField(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	sto.Set(Human{}, "Name", "required")
+
+	tag := sto.Get(reflect.TypeOf(Human{}), "bloop")
+
+	if tag != "" {
+		t.Errorf("tag should be empty string, got %s instead", tag)
+	}
+}
+
+func TestGetSchemaTagOverrideGetMultipleFields(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	sto.Set(Human{}, "Name", "required")
+	sto.Set(Human{}, "Sex", "required,enum=male|female|neither|both")
+
+	nameTag := sto.Get(reflect.TypeOf(Human{}), "Name")
+	sexTag := sto.Get(reflect.TypeOf(Human{}), "Sex")
+
+	if nameTag != "required" && sexTag != "required,enum=male|female|neither|both" {
+		t.Errorf("did not receive expected tag overrides, got %s and %s", nameTag, sexTag)
+	}
+}
+
+func TestGetSchemaTagOverrideGetMultipleKeys(t *testing.T) {
+	sto := GetSchemaTagOverride()
+	sto.Set(Human{}, "Name", "required")
+	sto.Set(Alien{}, "bloop", "required,enum=3.1415926535897932384626")
+
+	nameTag := sto.Get(reflect.TypeOf(Human{}), "Name")
+	bloopTag := sto.Get(reflect.TypeOf(Human{}), "bloop")
+
+	if nameTag != "required" && bloopTag != "required,enum=3.1415926535897932384626" {
+		t.Errorf("did not receive expected tag overrides, got %s and %s", nameTag, bloopTag)
+	}
+}


### PR DESCRIPTION
`Reflector` now has a field `Overrides` which takes interface `SchemaTagOverride`. 

```
type SchemaTagOverride interface {
	// Set should be given:
	// targetStruct - struct that contains the field to be overridden
	// targetField - name of the field that is to be overridden
	// tag - the provided jsonschema tag
	Set(targetStruct interface{}, targetField string, tag string) error
	// Get is used by this library to retrieve overrides
	Get(targetStructType reflect.Type, targetField string) string
}
```

The expected use case is for shared nested structs where validation is stricter on certain fields. For example a shared nested struct with field `Species` and tag `enum=Human|Dog|Alien` may be used by applications that want to declare a stricter tag `required,enum=Dog`

```
type SharedNestedStruct struct {
    Species `jsonschema:"enum=Human|Dog|Alien"`
}
```

**To override the Species jsonschema tag:**
```
    override := jsonschema.GetSchemaTagOverride()
    override.Set(SharedNestedStruct{}, "Species", "required,enum=Dog")
    
    r := &jsonschema.Reflector{Overrides: override}
    schema := r.Reflect(SharedNestedStruct{})
```