### PR TITLE
Handle encoding/json.RawMessage type as a map

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -295,6 +295,16 @@ func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type)
 		return rt
 
 	case reflect.Slice, reflect.Array:
+		// encoding/json.RawMessage is an alias for a bytes slice but need to be handled like a map
+		if t.Name() == "RawMessage" && t.PkgPath() == "encoding/json" {
+			rt := &Type{
+				Type:              "object",
+				PatternProperties: nil,
+			}
+
+			return rt
+		}
+
 		returnType := &Type{}
 		if t.Kind() == reflect.Array {
 			returnType.MinItems = t.Len()


### PR DESCRIPTION
Currently, a field with a [encoding/json.RawMessage](https://golang.org/pkg/encoding/json/#RawMessage) will output in JSON schema as an array of integer:
```
{
    "items": {
        "type": "integer"
    },
    "type": "array"
}
```
basically because it's an alias to a slice of bytes.

However it should output to an *object*:
```
{
    "type": "object"
}
```
the same way it is done for *map[string]interface{}* : https://github.com/discovery-digital/jsonschema/blob/a24f638c6796a60cff05607432e866c24e5111a6/reflect.go#L281